### PR TITLE
Fix - Resolve Null or Order value for condition references

### DIFF
--- a/src/Helper.ps1
+++ b/src/Helper.ps1
@@ -36,7 +36,7 @@ Function Get-Action {
             Write-Warning ('Action {0} has no runafter property' -f $actionName)
             #Set runafter to parent if parent is not null
             if ($Parent) {
-                $runAfter = $Parent
+                $runAfter = $Parent  -replace '(-False|-True)', ''
             }
             else {
                 $runAfter = $null


### PR DESCRIPTION
Issue #39 and #41 have issues where the references that are below the condition statement are unable to locate the condition statement.  This is because the actionname is called condition, but it is looking for the parent actionname that is _condition-true_ or _condition-false_ which it is unable to locate as there is no parent called this.  This causing powershell to throw an exception.

